### PR TITLE
Loads shared product.js section chunk for all products

### DIFF
--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -20,6 +20,8 @@
       <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
         <% if (htmlWebpackPlugin.options.liquidTemplates[page].includes('customers/')) { %>
           <% conditions.push("template == 'customers/" + page.split('.').slice(1).join('.') + "'") %>
+        <% } else if (htmlWebpackPlugin.options.liquidTemplates[page].includes('product.')) { %>
+          <% conditions.push("template contains 'product'") %>
         <% } else { %>
           <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
         <% } %>
@@ -36,6 +38,12 @@
   <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
     <% if (htmlWebpackPlugin.options.liquidTemplates[chunk].includes('customers/')) { %>
       {%- if template == 'customers/<%= chunk.split('.').slice(1).join('.') %>' -%}
+        <script type="text/javascript" src="<%= src %>" defer></script>
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="script">
+      {%- endif -%}
+    <% } else if (htmlWebpackPlugin.options.liquidTemplates[chunk].includes('product.')) { %>  
+      {%- if template contains '<%= chunk.split('.').slice(1).join('.') %>' -%}
         <script type="text/javascript" src="<%= src %>" defer></script>
       {%- else -%}
         <link rel="prefetch" href="<%= src %>" as="script">


### PR DESCRIPTION
### Loads shared product.js section chunk for all products

Otherwise all sub `product.template_name` templates can't load product.js section's code.
Even worse we can't create more then 2 subproducts because shared across products and index chunk's file name turns too big because it appends all of them with @ as separator, leading to  inability to finish build process.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

